### PR TITLE
Made task matching slightly less flakey

### DIFF
--- a/grunt.el
+++ b/grunt.el
@@ -105,12 +105,12 @@ tasks."
   (let* ((contents (with-temp-buffer
                      (insert-file-contents grunt-current-path)
                      (split-string (buffer-string) "\n"))))
-		(-map (lambda (line)
-						(string-match "[\"']\\\(.*?\\\)[\"\']" line)
-						(match-string 1 line))
-					(-filter (lambda (line)
-										 (string-match-p "registerTask" line))
-									 contents))))
+    (-map (lambda (line)
+            (string-match "[\"']\\\(.*?\\\)[\"\']" line)
+            (match-string 1 line))
+          (-filter (lambda (line)
+                     (string-match-p "registerTask" line))
+                   contents))))
 
 (defun grunt-resolve-options ()
   "Set up the arguments to the grunt binary

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -20,13 +20,13 @@
 (require 'grunt (f-expand "grunt.el" root-code-path))
 
 (if (not (boundp 'string-suffix-p))
-		(defun string-suffix-p (str1 str2 &optional ignore-case)
-			(let ((begin2 (- (length str2) (length str1)))
-						(end2 (length str2)))
-				(when (< begin2 0) (setq begin2 0))
-				(eq t (compare-strings str1 nil nil
-															 str2 begin2 end2
-															 ignore-case)))))
+    (defun string-suffix-p (str1 str2 &optional ignore-case)
+      (let ((begin2 (- (length str2) (length str1)))
+            (end2 (length str2)))
+        (when (< begin2 0) (setq begin2 0))
+        (eq t (compare-strings str1 nil nil
+                               str2 begin2 end2
+                               ignore-case)))))
 
 (defmacro with-sandbox (&rest body)
   "Evaluate BODY in an empty temporary directory."


### PR DESCRIPTION
Still not an ideal solution, but string matching should now work for single & double quotes by making it less specific.
Added a string-suffix-p function to grunt-test.el to allow tests to be run against older versions of Emacs.
