### PR TITLE
Fix #6: set process column width

### DIFF
--- a/grunt.el
+++ b/grunt.el
@@ -97,12 +97,16 @@ as needed."
                 "Execute which task: "
                 (grunt-resolve-registered-tasks) nil nil))
          (command (grunt--command task))
-         (buf (grunt--project-task-buffer))
-         (default-directory grunt-current-dir))
+         (buf (grunt--project-task-buffer task))
+         (default-directory grunt-current-dir)
+         (ret))
     (message "%s" command)
-    (async-shell-command command buf buf)))
+    (setq ret (async-shell-command command buf buf))
+    ;; handle window sizing: see #6
+    (grunt--set-process-dimensions buf)
+    ret))
 
-(defun grunt--project-task-buffer ()
+(defun grunt--project-task-buffer (task)
   (let* ((bufname (format "*grunt-%s*<%s>" task grunt-current-project))
          (buf (get-buffer bufname))
          (proc (get-buffer-process buf)))
@@ -161,7 +165,12 @@ gruntfile and pulls in the user specified `grunt-options'"
             grunt-current-project (car (last (split-string gruntfile-dir "/" t)))
             grunt-current-path (format "%sGruntfile.js" gruntfile-dir)))))
 
-
+(defun grunt--set-process-dimensions (buf)
+  (let ((process (get-buffer-process buf)))
+    (when process
+      (set-process-window-size process
+                               (window-height)
+                               (window-width)))))
 
 (provide 'grunt)
 ;;; grunt.el ends here

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -115,3 +115,13 @@
      (grunt-exec)
      (grunt-exec)
      (should t))))
+
+(ert-deftest should-set-column-width ()
+  (with-grunt-sandbox
+   (let ((process-resized 0))
+     (noflet ((ido-completing-read (&rest any) "build")
+              (async-shell-command (&rest args) args)
+              (grunt--set-process-dimensions (buf)
+                (setq process-resized (1+ process-resized))))
+       (grunt-exec)
+       (should process-resized)))))


### PR DESCRIPTION
`grunt-tsc` explicitly looks up the column width of the window, and then
does math with that number. In particular, it tries to trim down an
error message by a certain number of characters, but because our
window's column width is 0, it never trims the error message, and
`grunt-tsc` hangs into a while loop.

So, we use `set-process-window-size` to set our column size so that
`grunt-tsc` can pick it up properly.

@abingham this should fix your issue once it gets into master :D