### PR TITLE
Grunt-rerun task and binding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: emacs-lisp
+sudo: required
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/7736123/raw > travis.sh && source ./travis.sh
   - evm install emacs-24.4-bin --skip

--- a/grunt.el
+++ b/grunt.el
@@ -289,7 +289,8 @@ gruntfile and pulls in the user specified `grunt-options'"
 (defun grunt-clear-tasks-cache ()
   "Clear the cache of tasks."
   (interactive)
-  (setq grunt-current-tasks-cache nil))
+  (setq grunt-current-tasks-cache nil)
+	(setq grunt-previous-task nil))
 
 (defun grunt--set-process-dimensions (buf)
   "Set the dimensions of the process buffer BUF."

--- a/grunt.el
+++ b/grunt.el
@@ -129,7 +129,7 @@ argument when invoking `grunt-exec'."
   "The cache of current grunt tasks.")
 
 (defvar grunt-previous-task nil
-	"Previous task that was run.")
+  "Previous task that was run.")
 
 ;;;###autoload
 (defun grunt-exec (&optional pfx)
@@ -150,26 +150,26 @@ immaterial."
   (let* ((task (ido-completing-read
                 "Execute which task: "
                 (grunt-resolve-registered-tasks) nil nil)))
-		(setq grunt-previous-task task)
+    (setq grunt-previous-task task)
     (grunt--run task)))
 
 (defun grunt-rerun ()
-	"Rerun the previous grunt task."
+  "Rerun the previous grunt task."
   (interactive)
-	(unless grunt-previous-task
-		(error "You have not run a grunt task yet.  Run `grunt-exec` first"))
-	(grunt--run grunt-previous-task))
+  (unless grunt-previous-task
+    (error "You have not run a grunt task yet.  Run `grunt-exec` first"))
+  (grunt--run grunt-previous-task))
 
 (defun grunt--run (task)
   "Set up the process buffer and run TASK."
-	(let ((cmd (grunt--command task))
-				(buf (grunt--project-task-buffer task))
-				(ret nil))
-		(grunt--message (format "%s" cmd))
-		(setq ret (async-shell-command cmd buf buf))
-		(grunt--set-process-dimensions buf)
-		(grunt--set-process-read-only buf)
-		ret))
+  (let ((cmd (grunt--command task))
+        (buf (grunt--project-task-buffer task))
+        (ret nil))
+    (grunt--message (format "%s" cmd))
+    (setq ret (async-shell-command cmd buf buf))
+    (grunt--set-process-dimensions buf)
+    (grunt--set-process-read-only buf)
+    ret))
 
 (defun grunt--project-task-buffer (task)
   "Create a process buffer for the grunt TASK."
@@ -290,7 +290,7 @@ gruntfile and pulls in the user specified `grunt-options'"
   "Clear the cache of tasks."
   (interactive)
   (setq grunt-current-tasks-cache nil)
-	(setq grunt-previous-task nil))
+  (setq grunt-previous-task nil))
 
 (defun grunt--set-process-dimensions (buf)
   "Set the dimensions of the process buffer BUF."

--- a/grunt.el
+++ b/grunt.el
@@ -128,7 +128,7 @@ argument when invoking `grunt-exec'."
 (defvar grunt-current-tasks-cache nil
   "The cache of current grunt tasks.")
 
-(defvar grunt-previous-run nil
+(defvar grunt-previous-task nil
 	"Previous task that was run.")
 
 ;;;###autoload
@@ -149,29 +149,27 @@ immaterial."
   (when (and pfx (> pfx 1)) (grunt-clear-tasks-cache))
   (let* ((task (ido-completing-read
                 "Execute which task: "
-                (grunt-resolve-registered-tasks) nil nil))
-         (command (grunt--command task))
-         (buf (grunt--project-task-buffer task))
-         (default-directory grunt-current-dir)
-         (ret))
-    (grunt--message (format "%s" command))
-		(setq grunt-previous-run (list command buf))
-    (setq ret (async-shell-command command buf buf))
-    ;; handle window sizing: see #6
-    (grunt--set-process-dimensions buf)
-    (grunt--set-process-read-only buf)
-    ret))
+                (grunt-resolve-registered-tasks) nil nil)))
+		(setq grunt-previous-task task)
+    (grunt--run task)))
 
 (defun grunt-rerun ()
 	"Rerun the previous grunt task."
   (interactive)
-	(unless grunt-previous-run
+	(unless grunt-previous-task
 		(error "You have not run a grunt task yet.  Run `grunt-exec` first"))
-	(let ((command (car grunt-previous-run))
-				(buf (cadr grunt-previous-run)))
-		(async-shell-command command buf)
+	(grunt--run grunt-previous-task))
+
+(defun grunt--run (task)
+  "Set up the process buffer and run TASK."
+	(let ((cmd (grunt--command task))
+				(buf (grunt--project-task-buffer task))
+				(ret nil))
+		(grunt--message (format "%s" cmd))
+		(setq ret (async-shell-command cmd buf buf))
 		(grunt--set-process-dimensions buf)
-		(grunt--set-process-read-only buf)))
+		(grunt--set-process-read-only buf)
+		ret))
 
 (defun grunt--project-task-buffer (task)
   "Create a process buffer for the grunt TASK."

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -193,3 +193,10 @@
               (grunt-clear-tasks-cache () (setq cleared-cache t)))
        (grunt-exec 4)
        (should cleared-cache)))))
+
+(ert-deftest should-set-the-previous-task ()
+  (with-grunt-sandbox
+	 (noflet ((ido-completing-read (&rest any) "build")
+						(async-shell-command (&rest args) args))
+					 (grunt-exec)
+					 (should (string= "build" grunt-previous-task)))))


### PR DESCRIPTION
Me again :P

Based on this [comment](https://github.com/gempesaw/grunt.el/pull/10#issuecomment-127604286), I've thrown together a simple solution to re-running the previous task.

* I've added a `grunt-previous-task` which gets set when `grunt-exec` is run and cleared when the cache is cleared
* I've created a `grunt-rerun` function which will use the `grunt-previous-task` variable to execute
* Consolidated the common bits of `grunt-exec` into a `grunt--run` function which takes a task string
* I've also added a key binding to the process buffer which re runs the task in that buffer.

It seems to work quite nicely!