### PR TITLE
Process refactor

### DIFF
--- a/grunt.el
+++ b/grunt.el
@@ -167,6 +167,7 @@ immaterial."
         (proc nil))
     (grunt--message (format "%s" cmd))
     (setq proc (start-process-shell-command (buffer-name buf) buf cmd))
+    (set-process-filter proc #'grunt--apply-ansi-color)
     (grunt--set-process-dimensions buf)
     (grunt--set-process-read-only buf)
   proc))
@@ -304,6 +305,7 @@ gruntfile and pulls in the user specified `grunt-options'"
   "Set the dimensions of the process buffer BUF."
   (let ((process (get-buffer-process buf)))
     (when process
+      (display-buffer buf '(nil (allow-no-window . t)))
       (set-process-window-size process
                                (window-height)
                                (window-width)))))

--- a/grunt.el
+++ b/grunt.el
@@ -6,7 +6,7 @@
 ;; Author: Daniel Gempesaw <dgempesaw@sharecare.com>
 ;; Keywords: convenience, grunt
 ;; URL: https://github.com/gempesaw/grunt.el
-;; Package-Requires: ((dash "2.9.0"))
+;; Package-Requires: ((dash "2.9.0") (ansi-color "3.4.2"))
 ;; Created: 2014 Apr 1
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -37,6 +37,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 'ansi-color)
 
 (defgroup grunt nil
   "Execute grunt tasks from your Gruntfile from Emacs"
@@ -171,6 +172,17 @@ immaterial."
     (grunt--set-process-dimensions buf)
     (grunt--set-process-read-only buf)
   proc))
+
+(defun grunt--apply-ansi-color (proc string)
+  "Filter to function for process PROC to apply ansi color to STRING."
+  (message "APPLYING COLOR")
+  (when (buffer-live-p (process-buffer proc))
+    (with-current-buffer (process-buffer proc)
+      (let ((inhibit-read-only t))
+        ;; Insert the text, advancing the process marker.
+        (insert string)
+        (ansi-color-apply-on-region (process-mark proc) (point))
+        (set-marker (process-mark proc) (point))))))
 
 (defun grunt--project-task-buffer (task)
   "Create a process buffer for the grunt TASK."

--- a/grunt.el
+++ b/grunt.el
@@ -164,12 +164,12 @@ immaterial."
   "Set up the process buffer and run TASK."
   (let ((cmd (grunt--command task))
         (buf (grunt--project-task-buffer task))
-        (ret nil))
+        (proc nil))
     (grunt--message (format "%s" cmd))
-    (setq ret (async-shell-command cmd buf buf))
+    (setq proc (start-process-shell-command (buffer-name buf) buf cmd))
     (grunt--set-process-dimensions buf)
     (grunt--set-process-read-only buf)
-    ret))
+  proc))
 
 (defun grunt--project-task-buffer (task)
   "Create a process buffer for the grunt TASK."

--- a/grunt.el
+++ b/grunt.el
@@ -175,7 +175,6 @@ immaterial."
 
 (defun grunt--apply-ansi-color (proc string)
   "Filter to function for process PROC to apply ansi color to STRING."
-  (message "APPLYING COLOR")
   (when (buffer-live-p (process-buffer proc))
     (with-current-buffer (process-buffer proc)
       (let ((inhibit-read-only t))

--- a/grunt.el
+++ b/grunt.el
@@ -200,7 +200,7 @@ immaterial."
 Sets the buffer to non read only mode when it's erased, this should be reset
 as soon as the task begins running."
   (when (buffer-live-p buf)
-    (with-current-buffer buf (read-only-mode 0) (erase-buffer))))
+    (with-current-buffer buf (let ((inhibit-read-only t)) (erase-buffer)))))
 
 (defun grunt-resolve-registered-tasks ()
   "Build a list of Grunt tasks.

--- a/grunt.el
+++ b/grunt.el
@@ -179,7 +179,16 @@ immaterial."
     (when (and grunt-kill-existing-buffer buf proc)
       (set-process-query-on-exit-flag proc nil)
       (kill-buffer bufname))
+    (grunt--clear-task-buffer buf)
     (get-buffer-create bufname)))
+
+(defun grunt--clear-task-buffer (buf)
+  "Clears the task buffer BUF."
+  (when (buffer-live-p buf)
+    (with-current-buffer buf
+      (read-only-mode 0)
+      (erase-buffer)
+      (read-only-mode 1))))
 
 (defun grunt-resolve-registered-tasks ()
   "Build a list of Grunt tasks.

--- a/grunt.el
+++ b/grunt.el
@@ -183,12 +183,11 @@ immaterial."
     (get-buffer-create bufname)))
 
 (defun grunt--clear-task-buffer (buf)
-  "Clears the task buffer BUF."
+  "Clears the task buffer BUF.
+Sets the buffer to non read only mode when it's erased, this should be reset
+as soon as the task begins running."
   (when (buffer-live-p buf)
-    (with-current-buffer buf
-      (read-only-mode 0)
-      (erase-buffer)
-      (read-only-mode 1))))
+    (with-current-buffer buf (read-only-mode 0) (erase-buffer))))
 
 (defun grunt-resolve-registered-tasks ()
   "Build a list of Grunt tasks.

--- a/grunt.el
+++ b/grunt.el
@@ -180,6 +180,7 @@ immaterial."
     (with-current-buffer (process-buffer proc)
       (let ((inhibit-read-only t))
         ;; Insert the text, advancing the process marker.
+        (goto-char (process-mark proc))
         (insert string)
         (ansi-color-apply-on-region (process-mark proc) (point))
         (set-marker (process-mark proc) (point))))))

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -137,8 +137,7 @@
 (ert-deftest should-set-column-width ()
   (with-grunt-sandbox
    (let ((process-resized 0))
-     (noflet ((ido-completing-read (&rest any) "build")
-              (async-shell-command (&rest args) args)
+     (noflet ((ido-completing-read (&rest any) "build") 
               (grunt--set-process-dimensions (buf)
                                              (setq process-resized (1+ process-resized))))
        (grunt-exec)
@@ -146,8 +145,7 @@
 
 (ert-deftest should-set-process-to-read-only ()
   (with-grunt-sandbox
-   (noflet ((ido-completing-read (&rest any) "build")
-            (async-shell-command (&rest args) args))
+   (noflet ((ido-completing-read (&rest any) "build"))
      (grunt-exec)
      (set-buffer "*grunt-build*<has-gruntfile>")
      (should buffer-read-only))))
@@ -189,14 +187,12 @@
   (with-grunt-sandbox
    (let ((cleared-cache nil))
      (noflet ((ido-completing-read (&rest any) "build")
-              (async-shell-command (&rest args) args)
               (grunt-clear-tasks-cache () (setq cleared-cache t)))
        (grunt-exec 4)
        (should cleared-cache)))))
 
 (ert-deftest should-set-the-previous-task ()
   (with-grunt-sandbox
-   (noflet ((ido-completing-read (&rest any) "build")
-            (async-shell-command (&rest args) args))
+   (noflet ((ido-completing-read (&rest any) "build"))
      (grunt-exec)
      (should (string= "build" grunt-previous-task)))))

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -134,8 +134,6 @@
         (noflet ((ido-completing-read (&rest any) "build")
                  (erase-buffer () (setq called t)))
           (grunt-exec)
-          (should (not called))
-          (grunt-exec)
           (should called)))))
 
 (ert-deftest should-kill-existing-buffer ()

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -120,9 +120,9 @@
 (ert-deftest should-execute-grunt-commands ()
   (with-grunt-sandbox
    (noflet ((ido-completing-read (&rest any) "build")
-            (async-shell-command (&rest args) args))
+            (start-process-shell-command (&rest args) args))
      (let* ((args (grunt-exec))
-            (cmd (car args))
+            (cmd (cadr (cdr args)))
             (buf (buffer-name (cadr args))))
        (should (string-suffix-p "build" cmd))
        (should (string= "*grunt-build*<has-gruntfile>" buf))))))

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -169,6 +169,15 @@
              (grunt-exec)
              (should called)))))
 
+(ert-deftest should-apply-ansi-color-to-the-string ()
+  (with-grunt-sandbox
+   (let ((called nil))
+     (noflet ((ido-completing-read (&rest any) "build")
+              (ansi-color-apply-on-region () (setq called t)))
+      (grunt-exec)
+      ;; (should called)
+      ))))
+
 (ert-deftest should-not-clear-cache-with-same-gruntfile ()
   (with-grunt-sandbox
    (let ((grunt-cache-tasks t)

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -161,6 +161,14 @@
      (set-buffer "*grunt-build*<has-gruntfile>")
      (should buffer-read-only))))
 
+(ert-deftest should-set-process-filter-to-apply-ansi-color ()
+  (with-grunt-sandbox
+   (let ((called nil))
+     (noflet ((ido-completing-read (&rest any) "build")
+              (set-process-filter (p f) (setq called t)))
+             (grunt-exec)
+             (should called)))))
+
 (ert-deftest should-not-clear-cache-with-same-gruntfile ()
   (with-grunt-sandbox
    (let ((grunt-cache-tasks t)

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -127,6 +127,17 @@
        (should (string-suffix-p "build" cmd))
        (should (string= "*grunt-build*<has-gruntfile>" buf))))))
 
+(ert-deftest should-erase-contents-of-buffer ()
+  (with-grunt-sandbox
+      (let ((called nil)
+            (grunt-kill-existing-buffer nil))
+        (noflet ((ido-completing-read (&rest any) "build")
+                 (erase-buffer () (setq called t)))
+          (grunt-exec)
+          (should (not called))
+          (grunt-exec)
+          (should called)))))
+
 (ert-deftest should-kill-existing-buffer ()
   (with-grunt-sandbox
    (noflet ((ido-completing-read (&rest any) "build"))

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -120,7 +120,8 @@
 (ert-deftest should-execute-grunt-commands ()
   (with-grunt-sandbox
    (noflet ((ido-completing-read (&rest any) "build")
-            (start-process-shell-command (&rest args) args))
+            (start-process-shell-command (&rest args) args)
+            (set-process-filter (p f) nil))
      (let* ((args (grunt-exec))
             (cmd (cadr (cdr args)))
             (buf (buffer-name (cadr args))))


### PR DESCRIPTION
Refactored the code to use proper processes over the `async-shell-command`. Refactor includes:

* Displaying buffer in the same manner as `async-shell-command`
* Clear the contents of process output buffer between runs
* Apply `ansi-color` to the output buffer