### PR TITLE
Update to travis.yml to fix gist curl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: emacs-lisp
 sudo: required
 before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/7736123/raw > travis.sh && source ./travis.sh
+  - curl -fsSkL https://gist.githubusercontent.com/rejeep/7736123/raw > travis.sh && source ./travis.sh
   - evm install emacs-24.4-bin --skip
   - evm install $EVM_EMACS --use --skip
   - cask


### PR DESCRIPTION
Github seems to have updated it's serving of raw gists from `gist.github` domain to `gist.githubusercontent`

This branch fixes the `curl` command to prevent **`503s`**.

I'll merge this into all outstanding branches after, no need for a melpa release I don't think though.