### PR TITLE
Rerun fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ you. While in that window, you have the following keybinds:
   killed, the grunt task will still continue running. For example, you
   could <kbd>q</kbd> away a long running window like `grunt watch`.
 
-- <kbd>g</kbd>: rerun the most recently run Grunt task. Note that this
-  is _not_ necessarily the task in the current window! That is, if you
-  run `grunt FIRST_TASK` and then `grunt SECOND_TASK`, then go to the
-  buffer for `FIRST_TASK` and hit <kbd>g</kbd>, it will rerun
-  `SECOND_TASK`, since it's the _most recent_ task.
+- <kbd>g</kbd>: rerun that buffer's Grunt task.
 
 ### breaking changes
 

--- a/grunt.el
+++ b/grunt.el
@@ -169,6 +169,7 @@ immaterial."
     (setq ret (async-shell-command cmd buf buf))
     (grunt--set-process-dimensions buf)
     (grunt--set-process-read-only buf)
+    (grunt--set-process-buffer-task buf task)
     ret))
 
 (defun grunt--project-task-buffer (task)
@@ -308,13 +309,18 @@ This means making it read only and locally binding the 'q' key to quit."
     (read-only-mode)
     (grunt-process-minor-mode)))
 
+(defun grunt--set-process-buffer-task (buf task)
+  "Set a buffer local variable on BUF for the TASK it is running."
+  (with-current-buffer buf
+    (setq-local grunt-buffer-task task)))
+
 (defvar grunt-process-minor-mode-map (make-sparse-keymap)
   "Keymap while temp-mode is active.")
 
 (define-minor-mode grunt-process-minor-mode
   "Minor mode for grunt process key bindings."
   :init-value nil
-  (define-key grunt-process-minor-mode-map (kbd "g") 'grunt-rerun)
+  (define-key grunt-process-minor-mode-map (kbd "g") '(lambda () (interactive) (grunt--run (buffer-local-value 'grunt-buffer-task (current-buffer)))))
   (define-key grunt-process-minor-mode-map (kbd "q") '(lambda () (interactive) (quit-window))))
 
 (provide 'grunt)

--- a/grunt.el
+++ b/grunt.el
@@ -1,5 +1,5 @@
 ;;; grunt.el --- Some glue to stick Emacs and Gruntfiles together
-;; Version: 1.2.1
+;; Version: 1.2.2
 
 ;; Copyright (C) 2014  Daniel Gempesaw
 

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -200,3 +200,11 @@
             (async-shell-command (&rest args) args))
      (grunt-exec)
      (should (string= "build" grunt-previous-task)))))
+
+(ert-deftest should-set-the-buffer-local-task ()
+  (with-grunt-sandbox
+   (noflet ((ido-completing-read (&rest any) "build")
+            (async-shell-command (&rest args) args))
+     (grunt-exec)
+     (set-buffer "*grunt-build*<has-gruntfile>")
+     (should (string= "build" (buffer-local-value 'grunt-buffer-task (current-buffer)))))))


### PR DESCRIPTION
Added a fix for the re running of tasks.

It never occurred to me that someone might press the `g` key in a grunt buffer that wasn't the last one run! But to fix this, I've added a function which sets a buffer local variable on each grunt process with the task name that's being run inside it. Then I've bound the `g` key to call `grunt--run` with this buffer local variable to ensure that we rerun _that_ task.