### PR TITLE
fix #13: prevent `nil --help --no-color` from being called

### DIFF
--- a/grunt.el
+++ b/grunt.el
@@ -1,5 +1,5 @@
 ;;; grunt.el --- Some glue to stick Emacs and Gruntfiles together
-;; Version: 1.2.2
+;; Version: 1.2.3
 
 ;; Copyright (C) 2014  Daniel Gempesaw
 

--- a/grunt.el
+++ b/grunt.el
@@ -270,8 +270,11 @@ gruntfile and pulls in the user specified `grunt-options'"
 
 (defun grunt--command (task)
   "Return the grunt command for the specified TASK."
+  ;; if necessary, let's lookup the grunt executable again, and throw
+  ;; if we still can't find one...
   (unless grunt-base-command
-    (setq grunt-base-command (executable-find "grunt")))
+    (unless (setq grunt-base-command (executable-find "grunt"))
+      (error "Couldn't locate the grunt executable; please setq `grunt-base-command' manually")))
   (mapconcat 'identity `(,grunt-base-command ,(grunt-resolve-options) ,task) " "))
 
 (defun grunt--message (s)

--- a/grunt.el
+++ b/grunt.el
@@ -58,8 +58,8 @@ You may have to fix this if `grunt' isn't in your PATH."
   :type 'string
   :group 'grunt)
 
-(defcustom grunt-help-command (format "%s --help --no-color" grunt-base-command)
-  "Command to get the help section from grunt."
+(defcustom grunt-help-args "--help --no-color"
+  "Arguments to pass to grunt CLI to get the help section."
   :type 'string
   :group 'grunt)
 
@@ -244,8 +244,15 @@ To suggest all valid tasks, see `grunt-show-all-tasks'."
 This function will return the cached version of the command if
 the cache is not empty."
   (grunt--message "Building task list from grunt --help, one moment...")
-  (shell-command-to-string
-   (format "cd %s; %s" grunt-current-dir grunt-help-command)))
+  (let ((default-directory grunt-current-dir))
+    (shell-command-to-string (grunt--help-command))))
+
+(defun grunt--help-command ()
+  "Build an appropriate `grunt --help` command for the current project.
+
+Using `grunt--command' to generate the help command ensures that
+we have a valid `grunt-base-command'."
+  (grunt--command grunt-help-args))
 
 (defun grunt-resolve-options ()
   "Set up the arguments to the grunt binary.

--- a/grunt.el
+++ b/grunt.el
@@ -101,9 +101,9 @@ by grunt modules.
 If nil it will suggest only the user registered tasks.
 
 The default value is t which means that we resolve the tasks
-using the grunt-help-command method.  Since shelling out to run
-`grunt --help` can be slow, we also default to caching the tasks
-for the current project; see `grunt-cache-tasks' for more."
+using the `grunt--help-command' method.  Since shelling out to
+run `grunt --help` can be slow, we also default to caching the
+tasks for the current project; see `grunt-cache-tasks' for more."
   :type '(choice
           (const :tag "Read all tasks including ones loaded by grunt modules" t)
           (const :tag "Read only user registered tasks" nil))
@@ -192,7 +192,7 @@ just the user registerdTasks."
     (grunt--resolve-registered-tasks-from-gruntfile)))
 
 (defun grunt--resolve-registered-tasks-from-grunthelp ()
-  "Build a list of potential Grunt tasks from grunt-help-command.
+  "Build a list of potential Grunt tasks from `grunt--help-command'.
 
 The list is constructed performing the `grunt --help` command, or
 similar, and narrowing down to the Available tasks section before
@@ -228,7 +228,7 @@ To suggest all valid tasks, see `grunt-show-all-tasks'."
                    contents))))
 
 (defun grunt--get-help-tasks ()
-  "Return a list of lines from the tasks region from the `grunt-help-command'."
+  "Return a list of lines from the tasks region from the `grunt--help-command'."
   (with-temp-buffer
     (insert (grunt--get-help))
     (goto-char 0)

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -92,22 +92,12 @@
 
 (ert-deftest should-use-valid-grunt-help-command ()
   (with-grunt-sandbox
-   (let ((prev-base-cmd grunt-base-command)
-         ;; in the case that we no longer use `grunt-help-command' at
-         ;; all, it's void and we need a sensible default.
-         (prev-help-cmd (if (boundp 'grunt-help-command)
-                            grunt-help-command
-                          "")))
+   (let ((grunt-base-command nil)
+         (grunt-help-command (format "%s --help --no-color" grunt-base-command)))
      ;; pretend like we couldn't resolve grunt-base-command, and that
      ;; grunt-help-command is in a similar quagmire
-     (setq grunt-base-command nil)
-     (setq grunt-help-command (format "%s --help --no-color" grunt-base-command))
      (noflet ((shell-command-to-string (&rest args) (car args)))
-       (should-not (string-match-p " nil --help" (grunt--get-help))))
-
-     ;; cleanup...
-     (setq grunt-base-command prev-base-cmd)
-     (setq grunt-help-command prev-help-cmd))))
+       (should-not (string-match-p " nil --help" (grunt--get-help)))))))
 
 (ert-deftest should-throw-when-missing-grunt-binary ()
   (with-grunt-sandbox

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -109,6 +109,12 @@
      (setq grunt-base-command prev-base-cmd)
      (setq grunt-help-command prev-help-cmd))))
 
+(ert-deftest should-throw-when-missing-grunt-binary ()
+  (with-grunt-sandbox
+   (noflet ((executable-find (binary) nil))
+     (let ((grunt-base-command nil))
+       (should-error (grunt--command))))))
+
 (ert-deftest should-resolve-registered-tasks-via-regex ()
   (with-grunt-sandbox
    (let ((grunt-show-all-tasks nil))

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -90,6 +90,25 @@
        (should (string= "build" (cadr result)))
        (should (eq 2 (length result)))))))
 
+(ert-deftest should-use-valid-grunt-help-command ()
+  (with-grunt-sandbox
+   (let ((prev-base-cmd grunt-base-command)
+         ;; in the case that we no longer use `grunt-help-command' at
+         ;; all, it's void and we need a sensible default.
+         (prev-help-cmd (if (boundp 'grunt-help-command)
+                            grunt-help-command
+                          "")))
+     ;; pretend like we couldn't resolve grunt-base-command, and that
+     ;; grunt-help-command is in a similar quagmire
+     (setq grunt-base-command nil)
+     (setq grunt-help-command (format "%s --help --no-color" grunt-base-command))
+     (noflet ((shell-command-to-string (&rest args) (car args)))
+       (should (not (string-match-p " nil --help" (grunt--get-help)))))
+
+     ;; cleanup...
+     (setq grunt-base-command prev-base-cmd)
+     (setq grunt-help-command prev-help-cmd))))
+
 (ert-deftest should-resolve-registered-tasks-via-regex ()
   (with-grunt-sandbox
    (let ((grunt-show-all-tasks nil))
@@ -102,7 +121,6 @@
               'utf-8
               (f-expand "Gruntfile.js" default-directory))
      (should (string= "test2" (car (grunt-resolve-registered-tasks)))))))
-
 
 (ert-deftest should-include-custom-options ()
   (with-grunt-sandbox

--- a/test/grunt-test.el
+++ b/test/grunt-test.el
@@ -103,7 +103,7 @@
      (setq grunt-base-command nil)
      (setq grunt-help-command (format "%s --help --no-color" grunt-base-command))
      (noflet ((shell-command-to-string (&rest args) (car args)))
-       (should (not (string-match-p " nil --help" (grunt--get-help)))))
+       (should-not (string-match-p " nil --help" (grunt--get-help))))
 
      ;; cleanup...
      (setq grunt-base-command prev-base-cmd)


### PR DESCRIPTION
noticed that `(grunt--command)` resets `grunt-base-command` already on its own, figured I might as well hook into that to generate the help command as well.