### PR TITLE
Declare variable for byte-compile warning

### DIFF
--- a/grunt.el
+++ b/grunt.el
@@ -140,6 +140,8 @@ happening.")
 (defvar grunt-previous-task nil
   "Previous task that was run.")
 
+(defvar grunt-buffer-task nil)
+
 ;;;###autoload
 (defun grunt-exec (&optional pfx)
   "Run tasks from gruntfile.  Calling with PFX will clear the cache of tasks.


### PR DESCRIPTION
This change fixes following byte-compile warning. Buffer local variable should be declared as global variable.

```
In grunt--set-process-buffer-task:
grunt.el:361:35:Warning: assignment to free variable `grunt-buffer-task'
```